### PR TITLE
added milestone link, released v1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,6 @@ Milestone1 - completed survey proposal can be found in [PROPOSAL.md](https://git
 
 |Name|Release Link|
 |---|---|
-|Milestone 1|[v1.0](https://github.com/UBC-MDS/survey_repo_CJCG/releases/tag/v1.0)|
+|Milestone 1|[v1.1](https://github.com/UBC-MDS/survey_repo_CJCG/releases/tag/v1.1)|
 |Milestone 2|[]()|
 |Milestone 3|[]()|


### PR DESCRIPTION
Had to create new release v1.1 because I was not confident about deleting v1.0. Did not want to lose repo.